### PR TITLE
Remove spurious bullet in SQL Search with LangChain nb

### DIFF
--- a/sql_search/sql_search_cohere_langchain.ipynb
+++ b/sql_search/sql_search_cohere_langchain.ipynb
@@ -19,8 +19,7 @@
     "\n",
     "**Requirements:**\n",
     "- You will need an access key to Cohere's API key, which you can sign up for at (https://dashboard.cohere.com/welcome/login). A free trial account will suffice, but will be limited to a small number of requests.\n",
-    "- After obtaining this key, store it in plain text in your home in directory in the `~/.cohere.key` file.\n",
-    "- Next, upload at least 1 pdf file into the `source-materials` subfolder under this notebook. The text in these pdf files will be used to augment your text generation request."
+    "- After obtaining this key, store it in plain text in your home in directory in the `~/.cohere.key` file."
    ]
   },
   {


### PR DESCRIPTION
The third bullet at the start of this notebook looks to be copied from somewhere else and doesn't make sense in the context of this example.